### PR TITLE
Migrate apiextensions.k8s.io to v1

### DIFF
--- a/config/crds/rigger_v1beta1_plan.yaml
+++ b/config/crds/rigger_v1beta1_plan.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
@@ -11,47 +11,58 @@ spec:
     kind: Plan
     plural: plans
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            ignoreNamespaces:
-              description: Do not sync from specified Namespaces.
-              items:
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              ignoreNamespaces:
+                description: Do not sync from specified Namespaces.
+                items:
+                  type: string
+                type: array
+              syncDestNamespace:
+                description: The namespace to register synced secrets.
                 type: string
-              type: array
-            syncDestNamespace:
-              description: The namespace to register synced secrets.
-              type: string
-            syncTargetSecretName:
-              description: Secret name of the target to sync.
-              type: string
-          type: object
-        status:
-          properties:
-            lastIgnoreNamespaces:
-              items:
+              syncTargetSecretName:
+                description: Secret name of the target to sync.
                 type: string
-              type: array
-            lastSyncDestNamespace:
-              type: string
-            lastSyncTargetSecretName:
-              type: string
-          type: object
-  version: v1beta1
+            type: object
+          status:
+            properties:
+              lastIgnoreNamespaces:
+                items:
+                  type: string
+                type: array
+              lastSyncDestNamespace:
+                type: string
+              lastSyncTargetSecretName:
+                type: string
+            type: object
+    additionalPrinterColumns:
+    - description: |-
+        CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+        Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
## Why

apiextensions.k8s.io/v1beta1 is deprecated.

## What

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#customresourcedefinition-v122